### PR TITLE
Update w_wad.c to fix problems on non-Linux OSes

### DIFF
--- a/src/wadfile/w_wad.c
+++ b/src/wadfile/w_wad.c
@@ -43,9 +43,7 @@
 #endif
 
 #ifndef __APPLE__
-#include <malloc.h>
-#else
-#include <malloc/malloc.h>
+#include <stdlib.h>
 #endif
 
 #include "doomtype.h"


### PR DESCRIPTION
Swapped out the define so that it will build on other OSes, such as FreeBSD that do not use malloc.h. Linux shouldn't suffer as they've deprecated the old function as is.