### PR TITLE
Fixes for CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,35 @@ option(ENGINE "Build Doom64EX" ON)
 option(TESTING "Build unit tests" ON)
 
 ##------------------------------------------------------------------------------
+## CMake functions
+##
+
+function(add_include_directories)
+  unset(NEW_INCLUDES)
+  foreach (ARG ${ARGN})
+    list(APPEND NEW_INCLUDES ${ARG})
+  endforeach ()
+  set(INCLUDES ${INCLUDES} ${NEW_INCLUDES} PARENT_SCOPE)
+endfunction()
+
+function(add_sources PREFIX)
+  unset(NEW_SOURCES)
+  foreach (ARG ${ARGN})
+    list(APPEND NEW_SOURCES "${SOURCE_ROOT_DIR}/${PREFIX}/${ARG}")
+  endforeach ()
+  set(SOURCES ${SOURCES} ${NEW_SOURCES} PARENT_SCOPE)
+  set(INCLUDES ${INCLUDES} "${SOURCE_ROOT_DIR}/${PREFIX}" PARENT_SCOPE)
+endfunction()
+
+function(add_link_libraries)
+  unset(NEW_LIBRARIES)
+  foreach (ARG ${ARGN})
+    list(APPEND NEW_LIBRARIES ${ARG})
+  endforeach ()
+  set(LIBRARIES ${LIBRARIES} ${NEW_LIBRARIES} PARENT_SCOPE)
+endfunction()
+
+##------------------------------------------------------------------------------
 ## Include subprojects
 ##
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@
 ## 02111-1307, USA.
 ##
 
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.11)
 
 project(doom64ex C CXX)
 

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -81,7 +81,7 @@ add_link_libraries(${PNG_LIBRARIES})
 
 # FluidSynth
 find_package(FluidSynth REQUIRED)
-add_include_directories(${FLUIDSYNTH_INCLUDE_DIRS})
+add_include_directories(${FLUIDSYNTH_INCLUDE_DIR})
 add_link_libraries(${FLUIDSYNTH_LIBRARIES})
 
 # OpenGL

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -25,35 +25,6 @@
 set(SOURCE_ROOT_DIR "${CMAKE_SOURCE_DIR}/src/engine")
 
 ##------------------------------------------------------------------------------
-## CMake functions
-##
-
-function(add_include_directories)
-  unset(NEW_INCLUDES)
-  foreach (ARG ${ARGN})
-    list(APPEND NEW_INCLUDES ${ARG})
-  endforeach ()
-  set(INCLUDES ${INCLUDES} ${NEW_INCLUDES} PARENT_SCOPE)
-endfunction()
-
-function(add_sources PREFIX)
-  unset(NEW_SOURCES)
-  foreach (ARG ${ARGN})
-    list(APPEND NEW_SOURCES "${SOURCE_ROOT_DIR}/${PREFIX}/${ARG}")
-  endforeach ()
-  set(SOURCES ${SOURCES} ${NEW_SOURCES} PARENT_SCOPE)
-  set(INCLUDES ${INCLUDES} "${SOURCE_ROOT_DIR}/${PREFIX}" PARENT_SCOPE)
-endfunction()
-
-function(add_link_libraries)
-  unset(NEW_LIBRARIES)
-  foreach (ARG ${ARGN})
-    list(APPEND NEW_LIBRARIES ${ARG})
-  endforeach ()
-  set(LIBRARIES ${LIBRARIES} ${NEW_LIBRARIES} PARENT_SCOPE)
-endfunction()
-
-##------------------------------------------------------------------------------
 ## Set up external dependencies
 ##
 

--- a/src/kexlib/CMakeLists.txt
+++ b/src/kexlib/CMakeLists.txt
@@ -23,8 +23,13 @@
 ##
 
 ##------------------------------------------------------------------------------
-## CMake functions
+## Set up external dependencies
 ##
+
+# libpng
+find_package(PNG REQUIRED)
+add_include_directories(${PNG_INCLUDE_DIRS})
+add_link_libraries(${PNG_LIBRARIES})
 
 ##------------------------------------------------------------------------------
 ## Sources
@@ -40,8 +45,8 @@ file(GLOB_RECURSE CC_SOURCES "${CMAKE_SOURCE_DIR}/src/kexlib/*.cc")
 ##
 
 add_library(kexlib STATIC ${C_SOURCES} ${C_HEADERS} ${CC_SOURCES})
-target_include_directories(kexlib PRIVATE "${CMAKE_SOURCE_DIR}/include/kexlib")
-target_link_libraries(kexlib m png)
+target_include_directories(kexlib PRIVATE ${INCLUDES} "${CMAKE_SOURCE_DIR}/include/kexlib")
+target_link_libraries(kexlib m ${LIBRARIES})
 
 ##------------------------------------------------------------------------------
 ## Build tests
@@ -53,7 +58,7 @@ if (TESTING)
   file(GLOB_RECURSE TEST_SOURCES "${CMAKE_SOURCE_DIR}/test/kexlib/*.cc")
 
   add_executable(kexlib_test ${TEST_SOURCES})
-  target_include_directories(kexlib_test PRIVATE "${CMAKE_SOURCE_DIR}/include/kexlib" ${GTEST_INCLUDE_DIRS})
+  target_include_directories(kexlib_test PRIVATE ${INCLUDES} "${CMAKE_SOURCE_DIR}/include/kexlib" ${GTEST_INCLUDE_DIRS})
   target_link_libraries(kexlib_test kexlib ${GTEST_BOTH_LIBRARIES})
 
   add_test(AllTestsInKexlib COMMAND kexlib_test)


### PR DESCRIPTION
Fix broken libpng dependency for kexlib
Fix headers search path for FluidSynth
Move CMake helper functions to the root CMakeLists
Increase required CMake version to 2.8.11