### PR TITLE
Fix crash on unmaker pickup

### DIFF
--- a/src/engine/doom_main/d_englsh.h
+++ b/src/engine/doom_main/d_englsh.h
@@ -123,7 +123,7 @@
 #define GOTPLASMA       "You got the plasma gun!"
 #define GOTSHOTGUN      "You got the shotgun!"
 #define GOTSHOTGUN2     "You got the super shotgun!"
-#define GOTLASER        "What the !@#%* is this!"
+#define GOTLASER        "What the !@#%%%%* is this!"
 
 #define FOUNDSECRET     "You found a secret area!"
 


### PR DESCRIPTION
This fixes the problem reported in alexey-lysiuk/doom64ex-osx-build#3
The way CON_Printf() is handling messages percent character must be escaped twice, i.e. %%%% is needed to print the single percent character