### PR TITLE
Fix mispellings

### DIFF
--- a/src/engine/doom_main/d_ticcmd.h
+++ b/src/engine/doom_main/d_ticcmd.h
@@ -39,7 +39,7 @@ typedef struct {
     char    sidemove;    // *2048 for move
     short    angleturn;    // <<16 for angle delta
     short    pitch;
-    byte    consistancy;    // checks for net game
+    byte    consistency;    // checks for net game
     byte    chatchar;
     byte    buttons;
     byte    buttons2;

--- a/src/engine/game/g_game.c
+++ b/src/engine/game/g_game.c
@@ -102,7 +102,7 @@ static int      savecompatflags = 0;
 int             totalkills, totalitems, totalsecret;
 dboolean        precache        = true;     // if true, load all graphics at start
 
-byte            consistancy[MAXPLAYERS][BACKUPTICS];
+byte            consistency[MAXPLAYERS][BACKUPTICS];
 
 #define MAXPLMOVE       (forwardmove[1])
 #define TURBOTHRESHOLD  0x32
@@ -597,7 +597,7 @@ void G_BuildTiccmd(ticcmd_t* cmd) {
     pc = &Controls;
     dmemset(cmd, 0, sizeof(ticcmd_t));
 
-    cmd->consistancy = consistancy[consoleplayer][maketic % BACKUPTICS];
+    cmd->consistency = consistency[consoleplayer][maketic % BACKUPTICS];
 
     if(pc->key[PCKEY_RUN]) {
         speed = 1;
@@ -1048,8 +1048,8 @@ void G_Ticker(void) {
         basetic++;    // For tracers and RNG -- we must maintain sync
     }
     else {
-        // get commands, check consistancy,
-        // and build new consistancy check
+        // get commands, check consistency,
+        // and build new consistency check
         buf = (gametic / ticdup) % BACKUPTICS;
 
         for(i = 0; i < MAXPLAYERS; i++) {
@@ -1076,15 +1076,15 @@ void G_Ticker(void) {
 
                 if(netgame && !netdemo && !(gametic % ticdup)) {
                     if(gametic > BACKUPTICS
-                            && consistancy[i][buf] != cmd->consistancy) {
+                            && consistency[i][buf] != cmd->consistency) {
                         I_Error("consistency failure (%i should be %i)",
-                                cmd->consistancy, consistancy[i][buf], consoleplayer);
+                                cmd->consistency, consistency[i][buf], consoleplayer);
                     }
                     if(players[i].mo) {
-                        consistancy[i][buf] = players[i].mo->x;
+                        consistency[i][buf] = players[i].mo->x;
                     }
                     else {
-                        consistancy[i][buf] = 0;
+                        consistency[i][buf] = 0;
                     }
                 }
             }

--- a/src/engine/net/net_defs.h
+++ b/src/engine/net/net_defs.h
@@ -1,4 +1,4 @@
-// Emacs style mode select   -*- C++ -*- 
+// Emacs style mode select   -*- C++ -*-
 //-----------------------------------------------------------------------------
 //
 // Copyright(C) 2005 Simon Howard
@@ -139,7 +139,7 @@ typedef struct
 #define NET_TICDIFF_SIDE         (1 << 1)
 #define NET_TICDIFF_TURN         (1 << 2)
 #define NET_TICDIFF_BUTTONS      (1 << 3)
-#define NET_TICDIFF_CONSISTANCY  (1 << 4)
+#define NET_TICDIFF_CONSISTENCY  (1 << 4)
 #define NET_TICDIFF_CHATCHAR     (1 << 5)
 #define NET_TICDIFF_BUTTONS2     (1 << 6)
 #define NET_TICDIFF_PITCH		 (1 << 7)

--- a/src/engine/net/net_structrw.c
+++ b/src/engine/net/net_structrw.c
@@ -131,8 +131,8 @@ void NET_WriteTiccmdDiff(net_packet_t *packet, net_ticdiff_t *diff,
     }
     if (diff->diff & NET_TICDIFF_BUTTONS)
         NET_WriteInt8(packet, diff->cmd.buttons);
-    if (diff->diff & NET_TICDIFF_CONSISTANCY)
-        NET_WriteInt8(packet, diff->cmd.consistancy);
+    if (diff->diff & NET_TICDIFF_CONSISTENCY)
+        NET_WriteInt8(packet, diff->cmd.CONSISTENCY);
     if (diff->diff & NET_TICDIFF_CHATCHAR)
         NET_WriteInt8(packet, diff->cmd.chatchar);
 	if (diff->diff & NET_TICDIFF_BUTTONS2)
@@ -191,11 +191,11 @@ dboolean NET_ReadTiccmdDiff(net_packet_t *packet, net_ticdiff_t *diff,
         diff->cmd.buttons = val;
     }
 
-    if (diff->diff & NET_TICDIFF_CONSISTANCY)
+    if (diff->diff & NET_TICDIFF_CONSISTENCY)
     {
         if (!NET_ReadInt8(packet, &val))
             return false;
-        diff->cmd.consistancy = val;
+        diff->cmd.CONSISTENCY = val;
     }
 
     if (diff->diff & NET_TICDIFF_CHATCHAR)
@@ -235,8 +235,8 @@ void NET_TiccmdDiff(ticcmd_t *tic1, ticcmd_t *tic2, net_ticdiff_t *diff)
         diff->diff |= NET_TICDIFF_TURN;
     if (tic1->buttons != tic2->buttons)
         diff->diff |= NET_TICDIFF_BUTTONS;
-    if (tic1->consistancy != tic2->consistancy)
-        diff->diff |= NET_TICDIFF_CONSISTANCY;
+    if (tic1->CONSISTENCY != tic2->CONSISTENCY)
+        diff->diff |= NET_TICDIFF_CONSISTENCY;
     if (tic2->chatchar != 0)
         diff->diff |= NET_TICDIFF_CHATCHAR;
 	if (tic1->buttons2 != tic2->buttons2)
@@ -259,8 +259,8 @@ void NET_TiccmdPatch(ticcmd_t *src, net_ticdiff_t *diff, ticcmd_t *dest)
         dest->angleturn = diff->cmd.angleturn;
     if (diff->diff & NET_TICDIFF_BUTTONS)
         dest->buttons = diff->cmd.buttons;
-    if (diff->diff & NET_TICDIFF_CONSISTANCY)
-        dest->consistancy = diff->cmd.consistancy;
+    if (diff->diff & NET_TICDIFF_CONSISTENCY)
+        dest->CONSISTENCY = diff->cmd.CONSISTENCY;
 
     if (diff->diff & NET_TICDIFF_CHATCHAR)
         dest->chatchar = diff->cmd.chatchar;

--- a/src/engine/playloop/p_saveg.c
+++ b/src/engine/playloop/p_saveg.c
@@ -27,8 +27,8 @@
 //
 //-----------------------------------------------------------------------------
 
-#include <time.h> // [kex] - for saving the date and time
 
+#include <time.h> // [kex] - for saving the date and time
 #include "i_system.h"
 #include "g_game.h"
 #include "z_zone.h"

--- a/src/engine/wadgen/sndfont.c
+++ b/src/engine/wadgen/sndfont.c
@@ -568,7 +568,7 @@ void SF_WriteSoundFont(void)
 	Mem_Free((void **)&inst->bag.instbags);
 	Mem_Free((void **)&inst->gen.info);
 
-	WGen_Printf("Sucessfully created %s", outFile);
+	WGen_Printf("Successfully created %s", outFile);
 }
 
 //**************************************************************

--- a/src/engine/wadgen/wadgen.c
+++ b/src/engine/wadgen/wadgen.c
@@ -199,7 +199,7 @@ void WGen_Process(void)
 	Wad_WriteOutput(outFile);
 
 	// Done
-	WGen_Printf("Sucessfully created %s", outFile);
+	WGen_Printf("Successfully created %s", outFile);
 
 	// Write out the soundfont file
 #ifdef USE_SOUNDFONTS


### PR DESCRIPTION
Found these since I am trying to fix the lintian errors to maybe get this into Debian proper. Please review before committing. There was one "arg vs and" that I know enough is not a mistake. I'll have to add that to my lintian overrides