### PR TITLE
Fix wadgen for Windows

### DIFF
--- a/src/engine/wadgen/wadgen.c
+++ b/src/engine/wadgen/wadgen.c
@@ -213,7 +213,7 @@ void WGen_Printf(char *s, ...)
 	va_end(v);
 
 #ifdef _WIN32
-	MessageBox(NULL, msg, "Info", MB_OK | MB_ICONINFORMATION);
+	I_Printf("%s\n", msg); //Print to launcher console in Windows
 #else
 	printf("%s\n", msg);
 #endif


### PR DESCRIPTION
In Windows, -wadgen creates an info box the user must click "Okay" on an
inexcusable amount of times.

This fix prints everything to console and the game's launcher console.