### PR TITLE
Use Ubuntu trust as Travis CI base release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c++
-dist: precise
+dist: trusty
 sudo: required 
 
 matrix:


### PR DESCRIPTION
There doesn't seem to be a reason not to use Trusty (latest allowed by Travis CI). If you are curious, there are methods to test your build against multiple Linux distros [using Docker](https://github.com/ProfessorKaos64/ges-code/blob/develop-master/.travis.yml). I do this in ongoing build tests for Goldeneye: Source.

Build test for PR:
https://travis-ci.org/ProfessorKaos64/Doom64EX/builds/177659564