### PR TITLE
Fix automap

### DIFF
--- a/src/engine/automap/am_map.cc
+++ b/src/engine/automap/am_map.cc
@@ -1048,10 +1048,10 @@ void AM_Drawer(void) {
 }
 
 //
-// AM_RegisterCvars
+// AM_RegisterCommands
 //
 
-void AM_RegisterCvars(void) {
+void AM_RegisterCommands(void) {
     G_AddCommand("automap", CMD_Automap, 0);
     G_AddCommand("+automap_in", CMD_AutomapSetFlag, AF_ZOOMIN);
     G_AddCommand("-automap_in", CMD_AutomapSetFlag, AF_ZOOMIN|PCKF_UP);

--- a/src/engine/automap/am_map.h
+++ b/src/engine/automap/am_map.h
@@ -45,6 +45,6 @@ void AM_Stop(void);
 // Called on P_Start; resets automap variables
 void AM_Reset(void);
 
-void AM_RegisterCvars(void);
+void AM_RegisterCommands(void);
 
 #endif

--- a/src/engine/game/g_game.cc
+++ b/src/engine/game/g_game.cc
@@ -1628,7 +1628,7 @@ void G_Init(void) {
     G_AddCommand("setcamerastatic", CMD_PlayerCamera, 0);
     G_AddCommand("setcamerachase", CMD_PlayerCamera, 1);
     G_AddCommand("enddemo", CMD_EndDemo, 0);
-    AM_RegisterCvars();
+    AM_RegisterCommands();
 }
 
 //

--- a/src/engine/game/g_game.cc
+++ b/src/engine/game/g_game.cc
@@ -1628,6 +1628,7 @@ void G_Init(void) {
     G_AddCommand("setcamerastatic", CMD_PlayerCamera, 0);
     G_AddCommand("setcamerachase", CMD_PlayerCamera, 1);
     G_AddCommand("enddemo", CMD_EndDemo, 0);
+    AM_RegisterCvars();
 }
 
 //

--- a/src/engine/game/g_game.h
+++ b/src/engine/game/g_game.h
@@ -50,7 +50,6 @@ void G_Ticker(void);
 void G_ScreenShot(void);
 void G_RunTitleMap(void);
 void G_RunGame(void);
-void G_RegisterCvars(void);
 
 dboolean G_Responder(event_t* ev);
 

--- a/src/engine/misc/m_menu.h
+++ b/src/engine/misc/m_menu.h
@@ -57,7 +57,6 @@ void M_StartControlPanel(dboolean forcenext);
 
 void M_StartMainMenu(void);
 
-void M_RegisterCvars(void);
 
 
 

--- a/src/engine/playloop/p_setup.h
+++ b/src/engine/playloop/p_setup.h
@@ -37,7 +37,6 @@ void P_SetupLevel(int map, int playermask, skill_t skill);
 // Called by startup code.
 void P_Init(void);
 
-void P_RegisterCvars(void);
 
 //
 // [kex] mapinfo

--- a/src/engine/renderer/r_main.h
+++ b/src/engine/renderer/r_main.h
@@ -77,7 +77,6 @@ void R_SetupLevel(void);
 void R_SetViewAngleOffset(angle_t angle);
 void R_SetViewOffset(int offset);
 void R_DrawWireframe(dboolean enable);    //villsa
-void R_RegisterCvars(void);
 void R_SetViewMatrix(void);
 void R_RenderWorld(void);
 void R_RenderBSPNode(int bspnum);

--- a/src/engine/sound/s_sound.h
+++ b/src/engine/sound/s_sound.h
@@ -70,7 +70,6 @@ int S_GetActiveSounds(void);
 void S_StartMusic(int mnum);
 void S_StopMusic(void);
 
-void S_RegisterCvars(void);
 
 
 #endif

--- a/src/engine/statusbar/st_stuff.h
+++ b/src/engine/statusbar/st_stuff.h
@@ -56,7 +56,6 @@ void ST_DrawCrosshair(int x, int y, int slot, byte scalefactor, rcolor color);
 void ST_UpdateFlash(void);
 void ST_AddDamageMarker(mobj_t* target, mobj_t* source);
 void ST_ClearDamageMarkers(void);
-void ST_RegisterCvars(void);
 void ST_DisplayPendingWeapon(void);
 
 extern char player_names[MAXPLAYERS][MAXPLAYERNAME];

--- a/src/engine/system/i_video.h
+++ b/src/engine/system/i_video.h
@@ -58,6 +58,5 @@ extern int mouse_y;
 int I_MouseAccel(int val);
 void I_MouseAccelChange(void);
 
-void V_RegisterCvars(void);
 
 #endif


### PR DESCRIPTION
The automap commands was not working because the call to `AM_RegisterCvars()` got lost. 

This includes some minor cleanups.

Note: `I_RegisterCvars()` is unchanged.