### PR TITLE
Fix segmentation fault by calling SDL_CloseAudio() before deleting sequencer

### DIFF
--- a/src/engine/system/i_audio.cc
+++ b/src/engine/system/i_audio.cc
@@ -1089,6 +1089,11 @@ static void Seq_Shutdown(doomseq_t* seq) {
     SDL_WaitThread(seq->thread, NULL);
 
     //
+    // prevent calls to Audio_Play()
+    //
+    SDL_CloseAudio();
+
+    //
     // fluidsynth cleanup stuff
     //
     delete_fluid_synth(seq->synth);


### PR DESCRIPTION
Prevent calls to `Play_Audio()` which can lead to segmentation faults during `fluid_synth_write_s16` when the sequencer is deleted.

On my system doom64ex crashes when I quit a running game session. This seems to fix the issue.