### PR TITLE
Enable ^ to toggle console (in addition to `)

### DIFF
--- a/src/engine/console/con_console.cc
+++ b/src/engine/console/con_console.cc
@@ -373,6 +373,7 @@ dboolean CON_Responder(event_t* ev) {
         if(ev->type == ev_keydown) {
             switch(c) {
             case '`':
+            case '^':
                 console_state = CST_UP;
                 console_enabled = false;
                 break;
@@ -482,7 +483,7 @@ dboolean CON_Responder(event_t* ev) {
 
     case CST_UP:
     case CST_RAISE:
-        if(c == '`') {
+        if(c == '`' || c == '^') {
             if(ev->type == ev_keydown) {
                 console_state = CST_DOWN;
                 console_enabled = true;


### PR DESCRIPTION
I've never been able to access the console with my QWERTZ keyboard. This adds ^ as an additional key to toggle the console.

**Disclaimer**: I don't know if this causes trouble for anything else. ^ seems to be only used as a character in `src/engine/fmt/format.h` as center alignment character. 

