### PR TITLE
Fix building on macOS

### DIFF
--- a/include/imp/Prelude
+++ b/include/imp/Prelude
@@ -2,6 +2,7 @@
 #ifndef __IMP_PRELUDE__56107413
 #define __IMP_PRELUDE__56107413
 
+#include <array>
 #include <chrono>
 #include <memory>
 #include <string>

--- a/include/imp/util/ArrayView
+++ b/include/imp/util/ArrayView
@@ -4,12 +4,8 @@
 
 #include <type_traits>
 #include <iterator>
-
-/* Forward-declare some std stuff */
-namespace std {
-  template <class T, class Allocator> class vector;
-  template <class T, size_t N> struct array;
-}
+#include <array>
+#include <vector>
 
 namespace imp {
   template <class T>

--- a/include/imp/util/Convert
+++ b/include/imp/util/Convert
@@ -2,6 +2,7 @@
 #ifndef __IMP_CONVERT__63784703
 #define __IMP_CONVERT__63784703
 
+#include <cstdlib>
 #include <string>
 #include "Types"
 #include "StringView"
@@ -17,7 +18,7 @@ namespace imp {
   template <>
   inline int32 from_string<int32>(StringView str)
   {
-    return std::atoi(str.data());
+    return atoi(str.data());
   }
 
   template <>

--- a/include/imp/util/Endian
+++ b/include/imp/util/Endian
@@ -4,13 +4,14 @@
 
 #include "Types"
 
-#if defined(APPLE) && defined(_WIN32)
-// We assume that Apple devices and Windows only run on little endian CPUs.
+#if defined(_WIN32)
+// We assume that Windows only runs on little endian CPUs.
 // (Intel and ARM)
 # define BIG_ENDIAN 0x1234
 # define LITTLE_ENDIAN 0x4321
 # define BYTE_ORDER LITTLE_ENDIAN
-
+#elif defined(__APPLE__)
+# include <machine/endian.h>
 #else
 # include <endian.h>
 #endif
@@ -35,6 +36,27 @@ namespace imp {
 
   inline uint64 swap_bytes(uint64 x) noexcept
   { return __bswap_64(x); }
+}
+#elif defined(__APPLE__)
+# include <libkern/OSByteOrder.h>
+namespace imp {
+    inline int16 swap_bytes(int16 x) noexcept
+    { return OSSwapInt16(x); }
+
+    inline uint16 swap_bytes(uint16 x) noexcept
+    { return OSSwapInt16(x); }
+
+    inline int32 swap_bytes(int32 x) noexcept
+    { return OSSwapInt32(x); }
+
+    inline uint32 swap_bytes(uint32 x) noexcept
+    { return OSSwapInt32(x); }
+
+    inline int64 swap_bytes(int64 x) noexcept
+    { return OSSwapInt64(x); }
+
+    inline uint64 swap_bytes(uint64 x) noexcept
+    { return OSSwapInt64(x); }
 }
 #elif defined(__GNUC__) || defined(__clang__)
 namespace imp {

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -319,5 +319,9 @@ set_property(TARGET doom64ex PROPERTY CXX_STANDARD 14)
 ##
 
 if (NOT WIN32)
-  install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/doom64ex DESTINATION bin)
+  if (APPLE)
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/doom64ex.app/Contents/MacOS/doom64ex DESTINATION bin)
+  else ()
+    install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/doom64ex DESTINATION bin)
+  endif ()
 endif ()


### PR DESCRIPTION
This fixes building on macOS with latest Xcode and developer tools installed, using MacPorts to provide dependencies. Fixes `make install` although on macOS in a semi-hacky way, but this way makes it the same as on Linux. It is acceptable for developers.

For some reason, the forward declarations did not work with the latest Clang/Xcode, so I switched them to includes.

Also, I do not recall `atoi()` being in the `std` namespace? Was this a typo?

To make this more normal to macOS users, on `make install` you could recursively copy the `${CMAKE_CURRENT_BINARY_DIR}/doom64ex.app` directory to `/Applications`. But then I think you should copy `${CMAKE_BINARY_DIR}/kex.wad` to `~/Library/Appication Support/doom64ex/` to complete the job. And you would need to add what to run to generate the wad file, and where to put it (`~/Library/Appication Support/doom64ex/`).