### PR TITLE
Fix button texture after unpressing

### DIFF
--- a/src/engine/playloop/p_spec.cc
+++ b/src/engine/playloop/p_spec.cc
@@ -1932,17 +1932,17 @@ void P_UpdateSpecials(void) {
                 switch(buttonlist[i].where) {
                 case top:
                     sides[buttonlist[i].line->sidenum[0]].toptexture =
-                        buttonlist[i].btexture ^ 1;
+                        swx_start + ((buttonlist[i].btexture - swx_start) ^ 1);
                     break;
 
                 case middle:
                     sides[buttonlist[i].line->sidenum[0]].midtexture =
-                        buttonlist[i].btexture ^ 1;
+                        swx_start + ((buttonlist[i].btexture - swx_start) ^ 1);
                     break;
 
                 case bottom:
                     sides[buttonlist[i].line->sidenum[0]].bottomtexture =
-                        buttonlist[i].btexture ^ 1;
+                        swx_start + ((buttonlist[i].btexture - swx_start) ^ 1);
                     break;
                 }
 


### PR DESCRIPTION
For some reason, wall buttons look wrong after they were pressed and unpressed. Like: a button has 485 texture. You press it, it changes to 486, then after few frames, it should change back to 485, but instead changes to 487, you press it again, it becomes 488 etc.
This fixes it.
The lines were copied from p_switch.cc, lines 99, 111, 123.