### PR TITLE
doom64ex_pk3.txt does not exist

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,7 +157,7 @@ else()
   # Build doom64ex.pk3
   add_custom_target(pk3 ALL
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/distrib/doom64ex.pk3"
-    COMMAND "${CMAKE_COMMAND}" -E tar "cfv" "${CMAKE_BINARY_DIR}/doom64ex.pk3" --format=zip "--files-from=${CMAKE_SOURCE_DIR}/distrib/doom64ex_pk3.txt")
+    COMMAND "${CMAKE_COMMAND}" -E tar "cfv" "${CMAKE_BINARY_DIR}/doom64ex.pk3" --format=zip "*")
 
   # Install doom64ex.pk3
   if (NOT WIN32)


### PR DESCRIPTION
https://github.com/svkaiser/Doom64EX/commit/e3530f517e5a2adb70b509e7d3ed8fe4e9d38c7b broke everything by hardcoding a file that does not even exist.