### PR TITLE
Use installation directory (CMAKE_INSTALL_PREFIX) in search paths for doom64ex.pk3/doom64.wad

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,9 @@ if(MINGW)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -mwindows -static")
 endif(MINGW)
 
+# Add installation path as pre-processor definition
+add_definitions(-DINSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}")
+
 ##------------------------------------------------------------------------------
 ## Configure config.hh
 ##

--- a/src/engine/App.cc
+++ b/src/engine/App.cc
@@ -97,6 +97,8 @@ void app::main(int argc, char **argv)
     // Data files have to be in the cwd on Windows for compatibility reasons.
 #ifndef _WIN32
     auto data_dir = SDL_GetPrefPath("", "doom64ex");
+    // In Linux this returns the value of $XDG_DATA_HOME environment variable
+    // usually $HOME/.local/share
     if (data_dir) {
         _data_dir = data_dir;
         SDL_free(data_dir);
@@ -173,13 +175,14 @@ Optional<String> app::find_data_file(StringView name, StringView dir_hint)
 
 #if defined(__LINUX__) || defined(__OpenBSD__)
     const char *paths[] = {
+        "" INSTALL_PREFIX "/share/games/doom64ex/",
         "/usr/local/share/games/doom64ex/",
         "/usr/local/share/doom64ex/",
         "/usr/local/share/doom/",
         "/usr/share/games/doom64ex/",
         "/usr/share/doom64ex/",
         "/usr/share/doom/",
-        "/opt/doom64ex/",
+        "/opt/doom64ex/"
     };
 
     for (auto p : paths) {


### PR DESCRIPTION
Add pre-processor definition `-DINSTALL_PREFIX` with the value of `CMAKE_INSTALL_PREFIX` and add the path to the search list for `doom64ex.pk3` and `doom64.wad`.