### PR TITLE
Fixed 'noreturn' function 'app::main' returning after wadgen finished

### DIFF
--- a/src/engine/wadgen/wadgen.cc
+++ b/src/engine/wadgen/wadgen.cc
@@ -39,6 +39,7 @@
 #define MAX_ARGS 256
 char *ArgBuffer[MAX_ARGS + 1];
 
+[[noreturn]]
 void WGen_ShutDownApplication(void);
 
 //**************************************************************
@@ -178,6 +179,8 @@ void WGen_Process(char *path)
 }
 
 int M_CheckParm(const char *);
+
+[[noreturn]]
 void WGen_WadgenMain(void)
 {
 	int parm = M_CheckParm("-wadgen");
@@ -255,9 +258,11 @@ void WGen_UpdateProgress(const char *fmt, ...)
 //**************************************************************
 //**************************************************************
 
+[[noreturn]]
 void WGen_ShutDownApplication(void)
 {
 	Rom_Close();
+	exit(0);
 }
 
 //**************************************************************

--- a/src/engine/wadgen/wadgen.h
+++ b/src/engine/wadgen/wadgen.h
@@ -79,6 +79,7 @@ uint WGen_Swap32(unsigned int x);
 #define _PAD8(x)	x += (8 - ((uint) x & 7)) & 7
 #define _PAD16(x)	x += (16 - ((uint) x & 15)) & 15
 
+[[noreturn]]
 void WGen_WadgenMain();
 void WGen_Printf(const char *s, ...);
 void WGen_Complain(const char *fmt, ...);


### PR DESCRIPTION
This was leading to undefined behavior after wadgen completed. `app::main` is a `noreturn` function, but `WGen_WadgenMain` would return after completing.

On my system the `Release` build would segfault after generating the wads, and the `Debug` build would launch the main game loop after generating the wads. The expected behavior is the app should gracefully exit after generating the wads.

This fix required an `exit(0)` to be called from within `WGen_WadgenMain`, and I felt the call logically belonged in the `WGen_ShutDownApplication` function. Furthermore, both functions are now appropriate marked as `noreturn`.